### PR TITLE
Crab dev

### DIFF
--- a/H2TauTau/init.sh
+++ b/H2TauTau/init.sh
@@ -3,7 +3,7 @@ source /cvmfs/cms.cern.ch/cmsset_default.sh
 echo 'set crab3 environment'
 source /cvmfs/cms.cern.ch/crab3/crab.sh
 echo 'set cms vo proxy'
-voms-proxy-init -voms cms
+voms-proxy-init --rfc --voms cms
 cd ../..
 echo 'set cmssw environment...'
 cmsenv


### PR DESCRIPTION
The previous version of init.sh made gfal-ls return:
GSS Major Status: General failure

Using `voms-proxy-init --rfc --voms cms`, gfal-ls gives the right output (directories content).