### PR TITLE
EleTau channel + mT calculation update

### DIFF
--- a/H2TauTau/cfgPython/et/tauEle_2018_modular_cfg.py
+++ b/H2TauTau/cfgPython/et/tauEle_2018_modular_cfg.py
@@ -268,8 +268,8 @@ condition = None # lambda event : len(event.sel_taus)>2
 
 from CMGTools.H2TauTau.heppy.analyzers.Selector import Selector
 def select_tau(tau):
-    return tau.pt()    > 20  and \
-        abs(tau.eta()) < 2.3 and \
+    return tau.pt()    >= 20  and \
+        abs(tau.eta()) <= 2.3 and \
         abs(tau.leadChargedHadrCand().dz()) < 0.2 and \
         tau.tauID('decayModeFinding') > 0.5 and \
         abs(tau.charge()) == 1. and \
@@ -291,8 +291,8 @@ one_tau = cfg.Analyzer(
 )
 
 def select_electron(electron):
-    return electron.pt()    > 25  and \
-        abs(electron.eta()) < 2.1 and \
+    return electron.pt()    >= 25  and \
+        abs(electron.eta()) <= 2.1 and \
         abs(electron.dxy()) < 0.045 and \
         abs(electron.dz())  < 0.2 and \
         electron.passConversionVeto()     and \

--- a/H2TauTau/cfgPython/et/tauEle_2018_modular_cfg.py
+++ b/H2TauTau/cfgPython/et/tauEle_2018_modular_cfg.py
@@ -319,7 +319,7 @@ one_electron = cfg.Analyzer(
 def select_electron_dilepton_veto(electron):
     return electron.pt() > 15             and \
         abs(electron.eta()) < 2.5         and \
-        electron.cutBasedId('POG_SPRING16_25ns_v1_Veto') and \
+        electron.cutBasedId('POG_SPRING15_25ns_v1_Veto') and \
         abs(electron.dxy()) < 0.045       and \
         abs(electron.dz())  < 0.2         and \
         electron.iso_htt() < 0.3

--- a/H2TauTau/cfgPython/et/tauEle_2018_modular_cfg.py
+++ b/H2TauTau/cfgPython/et/tauEle_2018_modular_cfg.py
@@ -297,7 +297,7 @@ def select_electron(electron):
         abs(electron.dz())  < 0.2 and \
         electron.passConversionVeto()     and \
         electron.gsfTrack().hitPattern().numberOfLostHits(ROOT.reco.HitPattern.MISSING_INNER_HITS) <= 1 and \
-        electron.mvaIDRun2("Fall17Iso","wp90") 
+        electron.electronID("mvaEleID-Fall17-iso-V1-wp90") # electron.mvaIDRun2("Fall17Iso","wp90") 
 
 sel_electrons = cfg.Analyzer(
     Selector, 

--- a/H2TauTau/cfgPython/et/tauEle_2018_modular_cfg.py
+++ b/H2TauTau/cfgPython/et/tauEle_2018_modular_cfg.py
@@ -297,7 +297,7 @@ def select_electron(electron):
         abs(electron.dz())  < 0.2 and \
         electron.passConversionVeto()     and \
         electron.gsfTrack().hitPattern().numberOfLostHits(ROOT.reco.HitPattern.MISSING_INNER_HITS) <= 1 and \
-        electron.electronID("mvaEleID-Fall17-iso-V1-wp90") # electron.mvaIDRun2("Fall17Iso","wp90") 
+        electron.electronID("mvaEleID-Fall17-iso-V1-wp80") # electron.mvaIDRun2("Fall17Iso","wp90") 
 
 sel_electrons = cfg.Analyzer(
     Selector, 

--- a/H2TauTau/python/heppy/analyzers/DiLeptonAnalyzer.py
+++ b/H2TauTau/python/heppy/analyzers/DiLeptonAnalyzer.py
@@ -25,9 +25,9 @@ class DiLepton(object):
 
     def mTLeg2(self, met=None):
         if met:
-            return self.mT(self.leg1(), met)
+            return self.mT(self.leg2(), met)
         else:
-            return self.mT(self.leg1(), self.met)
+            return self.mT(self.leg2(), self.met)
 
     def mtTotal(self, met=None):
         if met:


### PR DESCRIPTION
- using loose cuts on pt and eta for baseline selection as for others channels
- use of POG_SPRING15_25ns_v1_Veto (and not SPRING16) for dileptonveto to be in line with the current doc
- electron selection using mvaEleID-Fall17-iso-V1-wp80 while waiting for a clear ID string to be set