### PR TITLE
Electron mvaID Fall17 V2

### DIFF
--- a/H2TauTau/cfgPython/et/tauEle_2018_modular_cfg.py
+++ b/H2TauTau/cfgPython/et/tauEle_2018_modular_cfg.py
@@ -82,9 +82,9 @@ selectedComponents = data_list if data else backgrounds + mssm_signals
 if test:
     cache = True
     comp = index.glob('HiggsVBF125')[0]
-    #comp.files = comp.files[:1]
-    #comp.splitFactor = 1
-    #comp.fineSplitFactor = 1
+    # comp.files = comp.files[:1]
+    # comp.splitFactor = 1
+    # comp.fineSplitFactor = 1
     selectedComponents = [comp]
     #comp.files = ['file1.root']
 
@@ -128,7 +128,7 @@ def select_electron(electron):
         abs(electron.dz())  < 0.2 and \
         electron.passConversionVeto()     and \
         electron.gsfTrack().hitPattern().numberOfLostHits(ROOT.reco.HitPattern.MISSING_INNER_HITS) <= 1 and \
-        electron.mvaIDRun2("Fall17IsoV2","wp90") 
+        electron.mvaIDRun2("Fall17noIsoV2","wp90") 
 
 sel_electrons = cfg.Analyzer(
     Selector, 

--- a/H2TauTau/cfgPython/et/tauEle_2018_modular_cfg.py
+++ b/H2TauTau/cfgPython/et/tauEle_2018_modular_cfg.py
@@ -82,9 +82,9 @@ selectedComponents = data_list if data else backgrounds + mssm_signals
 if test:
     cache = True
     comp = index.glob('HiggsVBF125')[0]
-    #comp.files = comp.files[:1]
-    #comp.splitFactor = 1
-    #comp.fineSplitFactor = 1
+    comp.files = comp.files[:1]
+    comp.splitFactor = 1
+    comp.fineSplitFactor = 1
     selectedComponents = [comp]
     #comp.files = ['file1.root']
 
@@ -128,7 +128,7 @@ def select_electron(electron):
         abs(electron.dz())  < 0.2 and \
         electron.passConversionVeto()     and \
         electron.gsfTrack().hitPattern().numberOfLostHits(ROOT.reco.HitPattern.MISSING_INNER_HITS) <= 1 and \
-        electron.electronID_passed("mvaEleID-Fall17-noIso-V2-wp90") 
+        electron.mva_passes("mvaEleID-Fall17-noIso-V2","wp90") 
 
 sel_electrons = cfg.Analyzer(
     Selector, 
@@ -151,7 +151,7 @@ def select_electron_dilepton_veto(electron):
     # implement V2 ! cutBasedElectronID-Fall17-94X-V2-veto
     return electron.pt() > 15             and \
         abs(electron.eta()) < 2.5         and \
-        electron.electronID_passed('cutBasedElectronID-Spring15-25ns-V1-standalone-veto') and \
+        electron.mva_passes('cutBasedElectronID-Spring15-25ns-V1-standalone', 'veto') and \
         abs(electron.dxy()) < 0.045       and \
         abs(electron.dz())  < 0.2         and \
         electron.iso_htt() < 0.3

--- a/H2TauTau/cfgPython/et/tauEle_2018_modular_cfg.py
+++ b/H2TauTau/cfgPython/et/tauEle_2018_modular_cfg.py
@@ -128,7 +128,7 @@ def select_electron(electron):
         abs(electron.dz())  < 0.2 and \
         electron.passConversionVeto()     and \
         electron.gsfTrack().hitPattern().numberOfLostHits(ROOT.reco.HitPattern.MISSING_INNER_HITS) <= 1 and \
-        electron.electronID("mvaEleID-Fall17-iso-V1-wp80") # electron.mvaIDRun2("Fall17Iso","wp90") 
+        electron.mvaIDRun2("Fall17IsoV2","wp90") 
 
 sel_electrons = cfg.Analyzer(
     Selector, 

--- a/H2TauTau/cfgPython/et/tauEle_2018_modular_cfg.py
+++ b/H2TauTau/cfgPython/et/tauEle_2018_modular_cfg.py
@@ -128,7 +128,7 @@ def select_electron(electron):
         abs(electron.dz())  < 0.2 and \
         electron.passConversionVeto()     and \
         electron.gsfTrack().hitPattern().numberOfLostHits(ROOT.reco.HitPattern.MISSING_INNER_HITS) <= 1 and \
-        electron.mvaIDRun2("Fall17NoIsoV2","wp90") 
+        electron.electronID("MVA_ID_nonIso_Fall17_V2_wp90") 
 
 sel_electrons = cfg.Analyzer(
     Selector, 

--- a/H2TauTau/cfgPython/et/tauEle_2018_modular_cfg.py
+++ b/H2TauTau/cfgPython/et/tauEle_2018_modular_cfg.py
@@ -82,11 +82,11 @@ selectedComponents = data_list if data else backgrounds + mssm_signals
 if test:
     cache = True
     comp = index.glob('HiggsVBF125')[0]
-    # comp.files = comp.files[:1]
-    # comp.splitFactor = 1
-    # comp.fineSplitFactor = 1
+    comp.files = comp.files[:1]
+    comp.splitFactor = 1
+    comp.fineSplitFactor = 1
     selectedComponents = [comp]
-    #comp.files = ['file1.root']
+    comp.files = ['/home/cms/torterotot/CMSSW_vanilla/CMSSW_9_4_8/Colin/Common/cfg/picked_events.root']
 
 events_to_pick = []
 
@@ -122,6 +122,10 @@ one_tau = cfg.Analyzer(
 )
 
 def select_electron(electron):
+    print 'pt = {}'.format(electron.pt())
+    for mva in "Fall17noIso", "Fall17Iso", "Fall17noIsoV2", "Fall17IsoV2":
+        print mva+'= {}'.format(electron.mvaRun2(mva))
+    print ' '
     return electron.pt()    >= 25  and \
         abs(electron.eta()) <= 2.1 and \
         abs(electron.dxy()) < 0.045 and \
@@ -148,6 +152,7 @@ one_electron = cfg.Analyzer(
 # dilepton veto ==============================================================
 
 def select_electron_dilepton_veto(electron):
+    # implement V2 ! cutBasedElectronID-Fall17-94X-V2-veto
     return electron.pt() > 15             and \
         abs(electron.eta()) < 2.5         and \
         electron.cutBasedId('POG_SPRING15_25ns_v1_Veto') and \

--- a/H2TauTau/cfgPython/et/tauEle_2018_modular_cfg.py
+++ b/H2TauTau/cfgPython/et/tauEle_2018_modular_cfg.py
@@ -128,7 +128,7 @@ def select_electron(electron):
         abs(electron.dz())  < 0.2 and \
         electron.passConversionVeto()     and \
         electron.gsfTrack().hitPattern().numberOfLostHits(ROOT.reco.HitPattern.MISSING_INNER_HITS) <= 1 and \
-        electron.electronID("MVA_ID_nonIso_Fall17_V2_wp90") 
+        electron.electronID_passed("mvaEleID-Fall17-noIso-V2-wp90") 
 
 sel_electrons = cfg.Analyzer(
     Selector, 
@@ -151,7 +151,7 @@ def select_electron_dilepton_veto(electron):
     # implement V2 ! cutBasedElectronID-Fall17-94X-V2-veto
     return electron.pt() > 15             and \
         abs(electron.eta()) < 2.5         and \
-        electron.cutBasedId('POG_SPRING15_25ns_v1_Veto') and \
+        electron.electronID_passed('cutBasedElectronID-Spring15-25ns-V1-standalone-veto') and \
         abs(electron.dxy()) < 0.045       and \
         abs(electron.dz())  < 0.2         and \
         electron.iso_htt() < 0.3

--- a/H2TauTau/cfgPython/et/tauEle_2018_modular_cfg.py
+++ b/H2TauTau/cfgPython/et/tauEle_2018_modular_cfg.py
@@ -82,11 +82,11 @@ selectedComponents = data_list if data else backgrounds + mssm_signals
 if test:
     cache = True
     comp = index.glob('HiggsVBF125')[0]
-    comp.files = comp.files[:1]
-    comp.splitFactor = 1
-    comp.fineSplitFactor = 1
+    #comp.files = comp.files[:1]
+    #comp.splitFactor = 1
+    #comp.fineSplitFactor = 1
     selectedComponents = [comp]
-    comp.files = ['/home/cms/torterotot/CMSSW_vanilla/CMSSW_9_4_8/Colin/Common/cfg/picked_events.root']
+    #comp.files = ['file1.root']
 
 events_to_pick = []
 
@@ -122,17 +122,13 @@ one_tau = cfg.Analyzer(
 )
 
 def select_electron(electron):
-    print 'pt = {}'.format(electron.pt())
-    for mva in "Fall17noIso", "Fall17Iso", "Fall17noIsoV2", "Fall17IsoV2":
-        print mva+'= {}'.format(electron.mvaRun2(mva))
-    print ' '
     return electron.pt()    >= 25  and \
         abs(electron.eta()) <= 2.1 and \
         abs(electron.dxy()) < 0.045 and \
         abs(electron.dz())  < 0.2 and \
         electron.passConversionVeto()     and \
         electron.gsfTrack().hitPattern().numberOfLostHits(ROOT.reco.HitPattern.MISSING_INNER_HITS) <= 1 and \
-        electron.mvaIDRun2("Fall17noIsoV2","wp90") 
+        electron.mvaIDRun2("Fall17NoIsoV2","wp90") 
 
 sel_electrons = cfg.Analyzer(
     Selector, 

--- a/H2TauTau/cfgPython/et/tauEle_2018_modular_cfg.py
+++ b/H2TauTau/cfgPython/et/tauEle_2018_modular_cfg.py
@@ -82,9 +82,9 @@ selectedComponents = data_list if data else backgrounds + mssm_signals
 if test:
     cache = True
     comp = index.glob('HiggsVBF125')[0]
-    comp.files = comp.files[:1]
-    comp.splitFactor = 1
-    comp.fineSplitFactor = 1
+    #comp.files = comp.files[:1]
+    #comp.splitFactor = 1
+    #comp.fineSplitFactor = 1
     selectedComponents = [comp]
     #comp.files = ['file1.root']
 

--- a/H2TauTau/python/heppy/analyzers/ElectronAnalyzer.py
+++ b/H2TauTau/python/heppy/analyzers/ElectronAnalyzer.py
@@ -11,6 +11,16 @@ class ElectronAnalyzer(Analyzer):
             self.cfg_ana.electrons,
             'std::vector<pat::Electron>'
         )
+
+        self.handles['Eleconversions'] = AutoHandle(
+            'reducedEgamma:reducedConversions',
+            'reco::ConversionCollection'
+        )
+
+        self.handles['Beam_spot'] = AutoHandle(
+            'offlineBeamSpot',
+            'reco::BeamSpot'
+        )
         
     def process(self, event):
         self.readCollections(event.input)
@@ -21,6 +31,8 @@ class ElectronAnalyzer(Analyzer):
             helectron.associatedVertex = event.vertices[0]
             helectron.event = event.input.object()
             helectron.rho = event.rho
+            helectron.convs = self.handles['Eleconversions'].product()
+            helectron.beam_spot = self.handles['Beam_spot'].product()
             output_electrons.append(helectron)
         setattr(event, self.cfg_ana.output, output_electrons)
         

--- a/H2TauTau/python/heppy/analyzers/ElectronAnalyzer.py
+++ b/H2TauTau/python/heppy/analyzers/ElectronAnalyzer.py
@@ -12,12 +12,12 @@ class ElectronAnalyzer(Analyzer):
             'std::vector<pat::Electron>'
         )
 
-        self.handles['Eleconversions'] = AutoHandle(
+        self.handles['conversions'] = AutoHandle(
             'reducedEgamma:reducedConversions',
             'reco::ConversionCollection'
         )
 
-        self.handles['Beam_spot'] = AutoHandle(
+        self.handles['beamspot'] = AutoHandle(
             'offlineBeamSpot',
             'reco::BeamSpot'
         )
@@ -31,8 +31,8 @@ class ElectronAnalyzer(Analyzer):
             helectron.associatedVertex = event.vertices[0]
             helectron.event = event.input.object()
             helectron.rho = event.rho
-            helectron.convs = self.handles['Eleconversions'].product()
-            helectron.beam_spot = self.handles['Beam_spot'].product()
+            helectron.conversions = self.handles['conversions'].product()
+            helectron.beamspot = self.handles['beamspot'].product()
             output_electrons.append(helectron)
         setattr(event, self.cfg_ana.output, output_electrons)
         

--- a/H2TauTau/python/heppy/ntuple/ntuple_variables.py
+++ b/H2TauTau/python/heppy/ntuple/ntuple_variables.py
@@ -161,7 +161,7 @@ metvars = Block(
 )
 
 electron_vars = dict(
-    id_e_mva_nt_loose = v(lambda x: x.mvaRun2('NonTrigSpring15MiniAOD')), 
+    id_e_mva_nt_loose = v(lambda x: x.physObj.userFloat("ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values")), 
     weight_tracking = v(lambda x: getattr(x, 'weight_tracking', 1. )),
     iso = v(lambda x: x.iso_htt()),
     dz = v(lambda x: x.dz()),

--- a/H2TauTau/python/heppy/sequence/common.py
+++ b/H2TauTau/python/heppy/sequence/common.py
@@ -374,7 +374,7 @@ sequence_beforedil = cfg.Sequence([
         muons, 
         electrons,
         genmatcher,
-        tauenergyscale,
+        # tauenergyscale,
 ])
 
 

--- a/H2TauTau/python/heppy/sequence/common.py
+++ b/H2TauTau/python/heppy/sequence/common.py
@@ -160,7 +160,7 @@ sel_muons_third_lepton_veto_cleaned = cfg.Analyzer(
 def select_electron_third_lepton_veto(electron):
     return electron.pt() > 10             and \
         abs(electron.eta()) < 2.5         and \
-        electron.electronID("MVA_ID_nonIso_Fall17_V2_wp90") and \
+        electron.electronID_passed("mvaEleID-Fall17-noIso-V2-wp90") and \
         abs(electron.dxy()) < 0.045       and \
         abs(electron.dz())  < 0.2         and \
         electron.passConversionVeto()     and \

--- a/H2TauTau/python/heppy/sequence/common.py
+++ b/H2TauTau/python/heppy/sequence/common.py
@@ -160,7 +160,7 @@ sel_muons_third_lepton_veto_cleaned = cfg.Analyzer(
 def select_electron_third_lepton_veto(electron):
     return electron.pt() > 10             and \
         abs(electron.eta()) < 2.5         and \
-        electron.electronID_passed("mvaEleID-Fall17-noIso-V2-wp90") and \
+        electron.mva_passes("mvaEleID-Fall17-noIso-V2", "wp90") and \
         abs(electron.dxy()) < 0.045       and \
         abs(electron.dz())  < 0.2         and \
         electron.passConversionVeto()     and \

--- a/H2TauTau/python/heppy/sequence/common.py
+++ b/H2TauTau/python/heppy/sequence/common.py
@@ -160,7 +160,7 @@ sel_muons_third_lepton_veto_cleaned = cfg.Analyzer(
 def select_electron_third_lepton_veto(electron):
     return electron.pt() > 10             and \
         abs(electron.eta()) < 2.5         and \
-        electron.electronID("mvaEleID-Fall17-iso-V1-wp90") and \
+        electron.mvaIDRun2("Fall17IsoV2","wp90") and \
         abs(electron.dxy()) < 0.045       and \
         abs(electron.dz())  < 0.2         and \
         electron.passConversionVeto()     and \

--- a/H2TauTau/python/heppy/sequence/common.py
+++ b/H2TauTau/python/heppy/sequence/common.py
@@ -160,7 +160,7 @@ sel_muons_third_lepton_veto_cleaned = cfg.Analyzer(
 def select_electron_third_lepton_veto(electron):
     return electron.pt() > 10             and \
         abs(electron.eta()) < 2.5         and \
-        electron.mvaIDRun2("Fall17IsoV2","wp90") and \
+        electron.mvaIDRun2("Fall17noIsoV2","wp90") and \
         abs(electron.dxy()) < 0.045       and \
         abs(electron.dz())  < 0.2         and \
         electron.passConversionVeto()     and \

--- a/H2TauTau/python/heppy/sequence/common.py
+++ b/H2TauTau/python/heppy/sequence/common.py
@@ -160,7 +160,7 @@ sel_muons_third_lepton_veto_cleaned = cfg.Analyzer(
 def select_electron_third_lepton_veto(electron):
     return electron.pt() > 10             and \
         abs(electron.eta()) < 2.5         and \
-        electron.mvaIDRun2("Fall17NoIsoV2","wp90") and \
+        electron.electronID("MVA_ID_nonIso_Fall17_V2_wp90") and \
         abs(electron.dxy()) < 0.045       and \
         abs(electron.dz())  < 0.2         and \
         electron.passConversionVeto()     and \

--- a/H2TauTau/python/heppy/sequence/common.py
+++ b/H2TauTau/python/heppy/sequence/common.py
@@ -160,7 +160,7 @@ sel_muons_third_lepton_veto_cleaned = cfg.Analyzer(
 def select_electron_third_lepton_veto(electron):
     return electron.pt() > 10             and \
         abs(electron.eta()) < 2.5         and \
-        electron.mvaIDRun2("Fall17noIsoV2","wp90") and \
+        electron.mvaIDRun2("Fall17NoIsoV2","wp90") and \
         abs(electron.dxy()) < 0.045       and \
         abs(electron.dz())  < 0.2         and \
         electron.passConversionVeto()     and \
@@ -374,7 +374,7 @@ sequence_beforedil = cfg.Sequence([
         muons, 
         electrons,
         genmatcher,
-        # tauenergyscale,
+        tauenergyscale,
 ])
 
 


### PR DESCRIPTION
- Updated mvaIDs selection criteria for electrons.
- Updated ElectronAnalyzer.py to attach needed infos to electrons.
:warning:  Goes along with [this PR for cmg-cmssw](https://github.com/cbernet/cmg-cmssw/pull/6)
:warning:  `cutBasedElectronID-Fall17-94X-V2-veto` remains to be implemented for post-syncNtuple.