### PR TITLE
Cut based ele id Fall17 94X V2 first implementation.

### DIFF
--- a/H2TauTau/cfgPython/et/tauEle_2018_modular_cfg.py
+++ b/H2TauTau/cfgPython/et/tauEle_2018_modular_cfg.py
@@ -148,10 +148,9 @@ one_electron = cfg.Analyzer(
 # dilepton veto ==============================================================
 
 def select_electron_dilepton_veto(electron):
-    # implement V2 ! cutBasedElectronID-Fall17-94X-V2-veto
     return electron.pt() > 15             and \
         abs(electron.eta()) < 2.5         and \
-        electron.mva_passes('cutBasedElectronID-Spring15-25ns-V1-standalone', 'veto') and \
+        electron.mva_passes('cutBasedElectronID-Fall17-94X-V2', 'veto') and \
         abs(electron.dxy()) < 0.045       and \
         abs(electron.dz())  < 0.2         and \
         electron.iso_htt() < 0.3


### PR DESCRIPTION
- updated `select_electron_dilepton_veto` in the eletau channel as requested in the [GitLab doc](https://gitlab.cern.ch/cms-htt/sync/blob/master/doc/baseline_selection_etau.md).

:warning: Goes along with [this PR](https://github.com/cbernet/cmg-cmssw/pull/8)