### PR TITLE
Fix export X509_USER_PROXY conflict with xrdcp.

### DIFF
--- a/H2TauTau/init.sh
+++ b/H2TauTau/init.sh
@@ -9,5 +9,5 @@ echo 'set cmssw environment...'
 cmsenv
 echo 'set cmssw environment:' $CMSSW_RELEASE_BASE
 cd CMGTools/H2TauTau
-export X509_USER_PROXY=$HOME/private/cms.proxy
+# export X509_USER_PROXY=$HOME/private/cms.proxy # conflict with xrdcp
 mkdir -p $HOME/private


### PR DESCRIPTION
Bug fix, see [this issue](https://github.com/cbernet/cmgtools-lite/issues/61).
The line is commented and not removed in the case it is necessary for an other reason. Then one may find an other solution to avoid the conflict.