### PR TITLE
METAnalyzer small code cleaning.

### DIFF
--- a/H2TauTau/python/heppy/analyzers/METAnalyzer.py
+++ b/H2TauTau/python/heppy/analyzers/METAnalyzer.py
@@ -192,9 +192,6 @@ class METAnalyzer(Analyzer):
         if not hasattr(event, 'photons'): # fast construction of photons list
             event.photons = [p for p in self.handles['photons'].product()]
 
-        pfcandidateClustered = event.electrons + event.muons \
-            + event.taus  + event.photons + event.jets
-
         pfcandidateClustered_ptcs = []
         for ptc in event.electrons :
             for assPFcand in ptc.physObj.associatedPackedPFCandidates():


### PR DESCRIPTION
The variable `pfcandidateClustered` is not used later (and at all !) in the `runFixEE2017` method so there is no need to declare it, the part of the code can be removed.